### PR TITLE
Fixed hook call for contao 4 compatibilty

### DIFF
--- a/contao/classes/RecipientManager.php
+++ b/contao/classes/RecipientManager.php
@@ -10,7 +10,7 @@
 
 class RecipientManager extends \System {
 
-    public function prepareRecipients(&$arrSubmitted, $arrLabels, $objForm) {
+    public function prepareRecipients(&$arrSubmitted, $arrLabels, $arrFields, $objForm) {
 
         $objFormField = \FormFieldModel::findOneBy(
             array('pid = ?', 'type = ?'),


### PR DESCRIPTION
Fixed issue #1

In Contao 4 the prepareFormData hook has changed:

The "prepareFormData" hook now passes $this as last argument, just like in any other hook.
https://docs.contao.org/books/extending-contao4/background/upgrade.html
